### PR TITLE
Circular Dependencies between Part/Block; fixes #108

### DIFF
--- a/src/main/java/App/DEHMDSYSMLPlugin.java
+++ b/src/main/java/App/DEHMDSYSMLPlugin.java
@@ -73,6 +73,8 @@ import Services.MappingConfiguration.IMappingConfigurationService;
 import Services.MappingConfiguration.MagicDrawMappingConfigurationService;
 import Services.MappingEngineService.IMappingEngineService;
 import Services.MappingEngineService.MappingEngineService;
+import Services.ModelConsistency.CircularDependencyValidationService;
+import Services.ModelConsistency.ICircularDependencyValidationService;
 import Services.Stereotype.IStereotypeService;
 import Services.Stereotype.StereotypeService;
 import Services.AdapterInfo.IAdapterInfoService;
@@ -86,8 +88,10 @@ import ViewModels.MagicDrawObjectBrowserViewModel;
 import ViewModels.RequirementImpactViewViewModel;
 import ViewModels.TransferControlViewModel;
 import ViewModels.ContextMenu.HubBrowserContextMenuViewModel;
+import ViewModels.Dialogs.AlertAcyclicDependencyDetectedDialogViewModel;
 import ViewModels.Dialogs.DstToHubMappingConfigurationDialogViewModel;
 import ViewModels.Dialogs.HubToDstMappingConfigurationDialogViewModel;
+import ViewModels.Dialogs.Interfaces.IAlertAcyclicDependencyDetectedDialogViewModel;
 import ViewModels.Dialogs.Interfaces.IDstToHubMappingConfigurationDialogViewModel;
 import ViewModels.Dialogs.Interfaces.IHubToDstMappingConfigurationDialogViewModel;
 import ViewModels.Interfaces.IElementDefinitionImpactViewViewModel;
@@ -236,6 +240,7 @@ public class DEHMDSYSMLPlugin extends Plugin
             AppContainer.Container.addComponent(DirectedRelationshipsToBinaryRelationshipsMappingRule.class.getName(), DirectedRelationshipsToBinaryRelationshipsMappingRule.class);
             AppContainer.Container.addComponent(BinaryRelationshipsToDirectedRelationshipsMappingRule.class.getName(), BinaryRelationshipsToDirectedRelationshipsMappingRule.class);
             AppContainer.Container.addComponent(IStateMappingRule.class, StateMappingRule.class);
+            AppContainer.Container.as(CACHE).addComponent(ICircularDependencyValidationService.class, CircularDependencyValidationService.class);
 
             AppContainer.Container.addComponent(IMappingConfigurationService.class, MagicDrawMappingConfigurationService.class);
             AppContainer.Container.addComponent(IMagicDrawUILogService.class, MagicDrawUILogService.class);
@@ -261,6 +266,7 @@ public class DEHMDSYSMLPlugin extends Plugin
             AppContainer.Container.addConfig("TElement", Class.class);
             AppContainer.Container.as(Characteristics.USE_NAMES).addComponent(IMappedElementListViewViewModel.class, MappedElementListViewViewModel.class);
             AppContainer.Container.addComponent(IMappingListViewViewModel.class, MagicDrawMappingListViewViewModel.class);
+            AppContainer.Container.addComponent(IAlertAcyclicDependencyDetectedDialogViewModel.class.getSimpleName(), AlertAcyclicDependencyDetectedDialogViewModel.class);
         }
         catch (Exception exception) 
         {

--- a/src/main/java/Services/MagicDrawSession/IMagicDrawSessionService.java
+++ b/src/main/java/Services/MagicDrawSession/IMagicDrawSessionService.java
@@ -29,6 +29,7 @@ import com.nomagic.magicdraw.core.Project;
 import com.nomagic.uml2.ext.magicdraw.classes.mdkernel.Element;
 import com.nomagic.uml2.ext.magicdraw.classes.mdkernel.Package;
 
+import Reactive.ObservableValue;
 import io.reactivex.Observable;
 
 /**
@@ -54,8 +55,7 @@ public interface IMagicDrawSessionService
 	boolean HasAnyOpenSession();
 
 	/**
-	 * Gets the {@linkplain Observable} of {@linkplain Boolean} that indicates when
-	 * the emitted Project gets saved
+	 * Gets the {@linkplain Observable} of {@linkplain Boolean} that indicates whenever the session has been updated
 	 * 
 	 * @return an {@linkplain Observable} of {@linkplain Boolean}
 	 */
@@ -95,4 +95,18 @@ public interface IMagicDrawSessionService
      * @return a {@linkplain Collection} of {@linkplain Element}
      */
     Collection<Element> GetProjectElements();
+
+    /**
+     * Gets the Session Event {@linkplain ObservableValue}
+     * 
+     * @return an {@linkplain ObservableValue} of {@linkplain Boolean}
+     */
+    ObservableValue<Boolean> GetSessionEvent();
+
+    /**
+     * Gets an {@linkplain Observable} of {@linkplain Boolean} indicating the subscribers whenever the open document gets saved
+     * 
+     * @return an {@linkplain Observable} of {@linkplain Boolean}
+     */
+    Observable<Boolean> ProjectSaved();
 }

--- a/src/main/java/Services/MagicDrawSession/MagicDrawSessionService.java
+++ b/src/main/java/Services/MagicDrawSession/MagicDrawSessionService.java
@@ -31,6 +31,7 @@ import com.nomagic.magicdraw.core.project.ProjectEventListener;
 import com.nomagic.uml2.ext.magicdraw.classes.mdkernel.Element;
 import com.nomagic.uml2.ext.magicdraw.classes.mdkernel.Package;
 
+import Reactive.ObservableValue;
 import io.reactivex.Observable;
 
 /**
@@ -71,11 +72,38 @@ public class MagicDrawSessionService implements IMagicDrawSessionService
      * @return an {@linkplain Observable} of {@linkplain Boolean}
      */
     @Override
-    public Observable<Boolean> SessionUpdated() 
+    public Observable<Boolean> ProjectSaved() 
     {
         return this.projectEventListener.ProjectSaved();
     }
-
+    
+    /**
+     * Backing field for {@linkplain #GetSessionEvent()}
+     */
+    private ObservableValue<Boolean> sessionEvent = new ObservableValue<>();
+    
+    /**
+     * Gets the Session Event {@linkplain ObservableValue}
+     * 
+     * @return an {@linkplain ObservableValue} of {@linkplain Boolean}
+     */
+    @Override
+    public ObservableValue<Boolean> GetSessionEvent()
+    {
+        return this.sessionEvent;
+    }
+    
+    /**
+     * Gets an {@linkplain Observable} of {@linkplain Boolean} indicating the subscribers whenever the session has been updated
+     * 
+     * @return an {@linkplain Observable} of {@linkplain Boolean}
+     */
+    @Override
+    public Observable<Boolean> SessionUpdated()
+    {
+        return this.sessionEvent.Observable();
+    }
+    
     /**
      * Gets an {@linkplain Observable} of {@linkplain Boolean} indicating if Cameo/MagicDraw has an open document
      * 

--- a/src/main/java/Services/Mapping/MapCommandService.java
+++ b/src/main/java/Services/Mapping/MapCommandService.java
@@ -291,7 +291,7 @@ public class MapCommandService implements IMapCommandService
                 .stream()
                 .filter(m -> m.GetIsValid())
                 .collect(Collectors.toList());
-                    
+
         StopWatch timer = StopWatch.createStarted();
         
         Task.Run(() -> this.MapSelectedElements(validMappedElements, mappingDirection), boolean.class)

--- a/src/main/java/Services/ModelConsistency/CircularDependencyValidationService.java
+++ b/src/main/java/Services/ModelConsistency/CircularDependencyValidationService.java
@@ -1,0 +1,377 @@
+/*
+ * CircularDependencyValidationService.java
+ *
+ * Copyright (c) 2020-2021 RHEA System S.A.
+ *
+ * Author: Sam Gerené, Alex Vorobiev, Nathanael Smiechowski 
+ *
+ * This file is part of DEH-MDSYSML
+ *
+ * The DEH-MDSYSML is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * The DEH-MDSYSML is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package Services.ModelConsistency;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.time.StopWatch;
+import org.apache.commons.lang3.tuple.MutablePair;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.nomagic.magicdraw.ui.notification.NotificationSeverity;
+import com.nomagic.uml2.ext.magicdraw.classes.mdkernel.Class;
+import com.nomagic.uml2.ext.magicdraw.classes.mdkernel.Element;
+import com.nomagic.uml2.ext.magicdraw.classes.mdkernel.NamedElement;
+import com.nomagic.uml2.ext.magicdraw.classes.mdkernel.Package;
+import com.nomagic.uml2.ext.magicdraw.classes.mdkernel.Property;
+
+import Reactive.ObservableCollection;
+import Services.MagicDrawSession.IMagicDrawSessionService;
+import Services.MagicDrawUILog.IMagicDrawUILogService;
+import Services.Stereotype.IStereotypeService;
+import Utils.Stereotypes.Stereotypes;
+import Utils.Tasks.ObservableTask;
+import Utils.Tasks.Task;
+import Utils.Tasks.TaskStatus;
+import ViewModels.MagicDrawObjectBrowser.Interfaces.IElementRowViewModel;
+import ViewModels.MagicDrawObjectBrowser.Rows.RootRowViewModel;
+import ViewModels.ObjectBrowser.Interfaces.IHaveContainedRows;
+
+/**
+ * The {@linkplain CircularDependencyValidationService} verify model consistency in terms of circular dependency between Parts in a given {@linkplain Package}
+ */
+public class CircularDependencyValidationService implements ICircularDependencyValidationService
+{
+    /**
+     * This current class logger
+     */
+    private Logger logger = LogManager.getLogger();
+
+    /**
+     * The {@linkplain IMagicDrawSessionService}
+     */
+    private final IMagicDrawSessionService sessionService;
+
+    /**
+     * The {@linkplain IMagicDrawUILogService}
+     */
+    private final IMagicDrawUILogService logService;
+
+    /**
+     * The {@linkplain IStereotypeService}
+     */
+    private final IStereotypeService stereotypeService;
+    
+    /**
+     * A value indicating whether the validation process is in progress
+     */
+    private boolean isValidationInProgress;
+
+    /**
+     * The reference to the {@linkplain ObservableTask} that is responsible for the validation
+     */
+    private ObservableTask<Boolean> validationTask;
+    
+    /**
+     * Backing field for {@linkplain #GetInvalidPaths()}
+     */
+    private ArrayListMultimap<Class, Collection<NamedElement>> invalidPaths = ArrayListMultimap.create();
+
+    /**
+     * Gets the {@linkplain Map} of all invalid path found when {@linkplain #Validate()}.
+     * The Key represent one top node in a path and the associated value is the collection of path/node children of the key 
+     */
+    @Override
+    public ArrayListMultimap<Class, Collection<NamedElement>> GetInvalidPaths()
+    {
+        return this.invalidPaths;
+    }
+
+    /**
+     * Initializes a new {@linkplain CircularDependencyValidationService}
+     * 
+     * @param sessionService the {@linkplain IMagicDrawSessionService}
+     * @param stereotypeService the {@linkplain IStereotypeService}
+     * @param logService the {@linkplain IMagicDrawUILogService}
+     */
+    public CircularDependencyValidationService(IMagicDrawSessionService sessionService, IStereotypeService stereotypeService, IMagicDrawUILogService logService)
+    {
+        this.sessionService = sessionService;
+        this.stereotypeService = stereotypeService;
+        this.logService = logService;
+        
+        this.sessionService.HasAnyOpenSessionObservable().subscribe(x -> this.InitializeValidation(false));        
+        this.sessionService.ProjectSaved().subscribe(x -> this.InitializeValidation(true));
+    }
+
+    /**
+     * Initializes the process of validating the open SysML project
+     * 
+     * @param cancellationRequested a value indicating whether the {@linkplain #validationTask} can be cancelled if running
+     */
+    private void InitializeValidation(boolean cancellationRequested)
+    {
+        if(!this.sessionService.HasAnyOpenSession())
+        {
+            return;
+        }
+        
+        if(this.isValidationInProgress && cancellationRequested && this.validationTask != null)
+        {
+            this.validationTask.Cancel();
+        }
+        else if (this.isValidationInProgress || (!cancellationRequested && this.validationTask != null))
+        {
+            return;
+        }            
+        
+        this.isValidationInProgress = true;
+
+        StopWatch timer = StopWatch.createStarted();
+        
+        this.validationTask = Task.Create(() -> this.Validate(), Boolean.class);
+        
+        this.validationTask.Observable()
+            .subscribe(task -> WhenValidationIsFinished(timer, task));
+        
+        this.validationTask.Run();
+    }
+
+    /**
+     * Occurs when the validation task is finished, also notifies the session service.
+     * 
+     * @param timer the ongoing timer
+     * @param task the {@linkplain Task} that is finished
+     */
+    private void WhenValidationIsFinished(StopWatch timer, Task<Boolean> task)
+    {
+        try
+        {
+            if(timer.isStarted())
+            {
+                timer.stop();
+            }
+   
+            if(task.GetStatus() == TaskStatus.Faulted)
+            {
+                this.logger.catching(task.GetException());
+                this.logService.Append("Failure to detect circular dependency SysML model. %s", NotificationSeverity.ERROR, task.GetException());
+                return;
+            }
+            
+            if(task.GetStatus() == TaskStatus.Cancelled)
+            {
+                return;
+            }
+
+            String baseInfo = String.format("Detecting circular dependency on the SysML model took %s ms to complete", timer.getTime(TimeUnit.MILLISECONDS));
+            
+            if(this.invalidPaths.isEmpty())
+            {
+                this.logger.info(baseInfo);
+            }
+            else
+            {
+                this.logService.Append("%s. [%s] contains circular dependency", NotificationSeverity.WARNING, baseInfo, this.sessionService.GetProjectName());
+            }                    
+        }
+        finally
+        {
+            this.isValidationInProgress = false;
+            this.sessionService.GetSessionEvent().Value(true);
+        }
+    }
+    
+    /**
+     * Validates the SysML model against any circular dependency
+     * 
+     * @return an assert
+     */
+    Boolean Validate()
+    {
+        this.invalidPaths.clear();
+        
+        final Set<Property> allPartProperties = new HashSet<>();
+
+        for(Class element : this.sessionService.GetAllProjectElements().stream()
+                .filter(x -> this.stereotypeService.DoesItHaveTheStereotype(x, Stereotypes.Block) 
+                        && !((Class)x).getName().contains("RollUp"))
+                .map(Class.class::cast)
+                .collect(Collectors.toList()))
+        {
+            allPartProperties.addAll(element.getOwnedAttribute().stream().filter(x -> this.stereotypeService.IsPartProperty(x)).collect(Collectors.toList()));
+        }
+        
+        ArrayList<MutablePair<Boolean, LinkedHashMap<String, NamedElement>>> nodes = new ArrayList<>();
+        
+        for (Property property : allPartProperties)
+        {            
+            nodes.clear();
+            
+            if(!(property.getObjectParent() instanceof Class))
+            {
+                continue;
+            }            
+
+            Class parentBlock = (Class) property.getObjectParent();
+            
+            nodes.add(MutablePair.of(false, new LinkedHashMap<String, NamedElement>()));            
+            nodes.get(0).getRight().put(parentBlock.getID(), parentBlock);
+
+            this.WalkThroughEachPath(nodes, property);
+            
+            for(LinkedHashMap<String, NamedElement> path : nodes.stream().filter(x -> x.getKey()).map(x -> x.getRight()).collect(Collectors.toList()))
+            {
+                this.invalidPaths.put(parentBlock, path.values().stream().skip(1).collect(Collectors.toList()));
+            }
+            
+        }
+        
+        return this.invalidPaths.isEmpty();
+    }
+
+    /**
+     * Recursively walk through each path until if finds again one dependency already encountered
+     * 
+     * @param nodes the {@linkplain Map} of id and {@linkplain NamedElement}
+     * @param property the current Par {@linkplain Property}
+     * @return a value indicating whether it has found recursion
+     */
+    private void WalkThroughEachPath(ArrayList<MutablePair<Boolean, LinkedHashMap<String, NamedElement>>> nodes, Property property)
+    {
+        if(property.getType() instanceof Class && this.stereotypeService.DoesItHaveTheStereotype(property.getType(), Stereotypes.Block))
+        {
+            Map<String, NamedElement> currentPath = nodes.get(nodes.size() - 1).getRight();
+            currentPath.put(property.getID(), property);
+            Class type = (Class)property.getType();
+
+            if(currentPath.put(type.getID(), type) != null)
+            {
+                nodes.get(nodes.size() - 1).left = true;
+                return;
+            }
+            
+            if(!type.getOwnedAttribute().isEmpty())
+            {
+                List<Property> ownedAttributes = type.getOwnedAttribute().stream()
+                            .filter(x -> this.stereotypeService.IsPartProperty(x))
+                            .collect(Collectors.toList());
+                
+                Map<String, NamedElement> previousPath = new HashMap<>(currentPath);
+                
+                for (int index = 0; index < ownedAttributes.size(); index++)
+                {
+                    if(index > 0)
+                    {
+                        nodes.add(MutablePair.of(false, new LinkedHashMap<String, NamedElement>(previousPath)));
+                    }
+                    
+                    this.WalkThroughEachPath(nodes, ownedAttributes.get(index));
+                }
+            }
+        }
+    }
+
+    /**
+     * Filters out the provided {@linkplain Collection} of {@linkplain Element}
+     * 
+     * @param elements the initial {@linkplain Collection} of {@linkplain Element} to filter
+     * @return a {@linkplain Pair} where the left element is a map of element involved in any recursion and the right one is the original list filtered out
+     */ 
+    @Override
+    public Pair<ArrayListMultimap<Class, Collection<NamedElement>>, Collection<Element>> FiltersInvalidElements(Collection<Element> elements)
+    {
+        ArrayListMultimap<Class, Collection<NamedElement>> invalidElements = ArrayListMultimap.create();
+        
+        for (Class block : elements.stream()
+                .filter(x -> x instanceof Class)
+                .map(x -> (Class)x)
+                .collect(Collectors.toList()))
+        {
+
+            if(this.invalidPaths.keySet().contains(block))
+            {
+                for(Collection<NamedElement> path : this.invalidPaths.get(block))
+                {
+                    invalidElements.put(block, path);
+                }
+                elements.remove(block);
+            }
+        }
+        
+        
+        return Pair.of(invalidElements, elements);
+    }
+    
+    /**
+     * Verifies that the Part {@linkplain Property} is not involved in any recursion, if so verifies that the provided {@linkplain RootRowViewModel} 
+     * does not contains a row representing the {@linkplain Property}
+     * 
+     * @param rootRowViewModel the Part {@linkplain RootRowViewModel}
+     * @param property the {@linkplain Property}
+     * @returns an assert
+     */
+    @Override
+    public boolean IsAlreadyPresent(RootRowViewModel rootRowViewModel, Property property)
+    {
+        if(!this.invalidPaths.isEmpty() && !this.invalidPaths.containsKey(property.getObjectParent()))
+        {
+            return false;
+        }
+        
+        return this.IsAlreadyPresent(property, rootRowViewModel.GetContainedRows());
+    }
+
+    /**
+     * 
+     * Verifies that the Part {@linkplain Property} is not present in the provided {@linkplain ObservableCollection} of {@linkplain IElementRowViewModel}
+     * does not contains a row representing the {@linkplain Property}
+     * 
+     * @param property the {@linkplain Property}
+     * @param containedRows an {@linkplain ObservableCollection} of {@linkplain IElementRowViewModel}
+     * @return an assert
+     */
+    @SuppressWarnings("unchecked")
+    private boolean IsAlreadyPresent(Property property, ObservableCollection<IElementRowViewModel<?>> containedRows)
+    {
+        for (IElementRowViewModel<?> element : containedRows)
+        {
+            if(element.GetClassKind() == Stereotypes.PartProperty && 
+                    Utils.Operators.Operators.AreTheseEquals(element.GetElement().getID(), property.getID()))
+            {
+                return true;
+            }
+            
+            if(element instanceof IHaveContainedRows)
+            {
+                return this.IsAlreadyPresent(property, ((IHaveContainedRows<IElementRowViewModel<?>>) element).GetContainedRows());
+            }
+        }
+        
+        return false;
+    }
+}

--- a/src/main/java/Services/ModelConsistency/ICircularDependencyValidationService.java
+++ b/src/main/java/Services/ModelConsistency/ICircularDependencyValidationService.java
@@ -1,0 +1,68 @@
+/*
+ * ICircularDependencyValidationService.java
+ *
+ * Copyright (c) 2020-2021 RHEA System S.A.
+ *
+ * Author: Sam Gerené, Alex Vorobiev, Nathanael Smiechowski 
+ *
+ * This file is part of DEH-MDSYSML
+ *
+ * The DEH-MDSYSML is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * The DEH-MDSYSML is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package Services.ModelConsistency;
+
+import java.util.Collection;
+import java.util.Map;
+
+import org.apache.commons.lang3.tuple.Pair;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.nomagic.uml2.ext.magicdraw.classes.mdkernel.Class;
+import com.nomagic.uml2.ext.magicdraw.classes.mdkernel.Element;
+import com.nomagic.uml2.ext.magicdraw.classes.mdkernel.NamedElement;
+import com.nomagic.uml2.ext.magicdraw.classes.mdkernel.Property;
+
+import ViewModels.MagicDrawObjectBrowser.Rows.RootRowViewModel;
+
+/**
+ * The {@linkplain ICircularDependencyValidationService} is the interface definition for the {@linkplain CircularDependencyValidationService}
+ */
+public interface ICircularDependencyValidationService
+{
+
+    /**
+     * Verifies that the Part {@linkplain Property} is not involved in any recursion, if so verifies that the provided {@linkplain RootRowViewModel} 
+     * does not contains a row representing the {@linkplain Property}
+     * 
+     * @param rootRowViewModel the Part {@linkplain RootRowViewModel}
+     * @param property the {@linkplain Property}
+     * @returns an assert
+     */
+    boolean IsAlreadyPresent(RootRowViewModel rootRowViewModel, Property property);
+
+    /**
+     * Filters out the provided {@linkplain Collection} of {@linkplain Element}
+     * 
+     * @param elements the initial {@linkplain Collection} of {@linkplain Element} to filter
+     * @return a {@linkplain Pair} where the left element is a map of element involved in any recursion and the right one is the original list filtered out
+     */
+    Pair<ArrayListMultimap<Class, Collection<NamedElement>>, Collection<Element>> FiltersInvalidElements(Collection<Element> elements);
+
+    /**
+     * Gets the {@linkplain Map} of all invalid path found when {@linkplain #Validate()}.
+     * The Key represent one top node in a path and the associated value is the collection of path/node children of the key 
+     */
+    ArrayListMultimap<Class, Collection<NamedElement>> GetInvalidPaths();
+}

--- a/src/main/java/Services/ModelConsistency/package-info.java
+++ b/src/main/java/Services/ModelConsistency/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * package-info.java
+ *
+ * Copyright (c) 2020-2021 RHEA System S.A.
+ *
+ * Author: Sam Gerené, Alex Vorobiev, Nathanael Smiechowski 
+ *
+ * This file is part of DEH-MDSYSML
+ *
+ * The DEH-MDSYSML is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * The DEH-MDSYSML is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package Services.ModelConsistency;

--- a/src/main/java/ViewModels/Dialogs/AlertAcyclicDependencyDetectedDialogViewModel.java
+++ b/src/main/java/ViewModels/Dialogs/AlertAcyclicDependencyDetectedDialogViewModel.java
@@ -1,0 +1,66 @@
+/*
+ * AlertAcyclicDependencyDetectedDialogViewModel.java
+ *
+ * Copyright (c) 2020-2021 RHEA System S.A.
+ *
+ * Author: Sam Gerené, Alex Vorobiev, Nathanael Smiechowski 
+ *
+ * This file is part of DEH-MDSYSML
+ *
+ * The DEH-MDSYSML is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * The DEH-MDSYSML is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package ViewModels.Dialogs;
+
+import java.util.Collection;
+import java.util.Map;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.nomagic.uml2.ext.magicdraw.classes.mdkernel.Class;
+import com.nomagic.uml2.ext.magicdraw.classes.mdkernel.NamedElement;
+
+import ViewModels.Dialogs.Interfaces.IAlertAcyclicDependencyDetectedDialogViewModel;
+import ViewModels.Interfaces.IViewModel;
+
+/**
+ * The {@linkplain AlertAcyclicDependencyDetectedDialogViewModel} is the view model for {@linkplain AlertAcyclicDependencyDetectedDialog} 
+ */
+public class AlertAcyclicDependencyDetectedDialogViewModel implements IViewModel, IAlertAcyclicDependencyDetectedDialogViewModel
+{
+    /**
+     * {@linkplain Map} where the key is a top node for each path where cyclic dependency was detected
+     */
+    private ArrayListMultimap<Class, Collection<NamedElement>> elements;
+    
+    /**
+     * Gets the invalid elements to be displayed
+     * 
+     * @return a {@linkplain Map} where the key is a top node for each path where cyclic dependency was detected
+     */
+    @Override
+    public ArrayListMultimap<Class, Collection<NamedElement>> GetInvalidElements()
+    {
+        return elements;
+    }
+    
+    /**
+     * Initializes a new {@linkplain AlertAcyclicDependencyDetectedDialogViewModel}
+     * 
+     * @param elements the {@linkplain Map} of invalid elements
+     */
+    public AlertAcyclicDependencyDetectedDialogViewModel(ArrayListMultimap<Class, Collection<NamedElement>> map)
+    {
+        this.elements = map;
+    }
+}

--- a/src/main/java/ViewModels/Dialogs/Interfaces/IAlertAcyclicDependencyDetectedDialogViewModel.java
+++ b/src/main/java/ViewModels/Dialogs/Interfaces/IAlertAcyclicDependencyDetectedDialogViewModel.java
@@ -1,0 +1,48 @@
+/*
+ * IAlertAcyclicDependencyDetectedDialogViewModel.java
+ *
+ * Copyright (c) 2020-2021 RHEA System S.A.
+ *
+ * Author: Sam Gerené, Alex Vorobiev, Nathanael Smiechowski 
+ *
+ * This file is part of DEH-MDSYSML
+ *
+ * The DEH-MDSYSML is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * The DEH-MDSYSML is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package ViewModels.Dialogs.Interfaces;
+
+import java.util.Collection;
+import java.util.Map;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.nomagic.uml2.ext.magicdraw.classes.mdkernel.Class;
+import com.nomagic.uml2.ext.magicdraw.classes.mdkernel.NamedElement;
+
+import ViewModels.Dialogs.AlertAcyclicDependencyDetectedDialogViewModel;
+import ViewModels.Interfaces.IViewModel;
+
+/**
+ * The {@linkplain IAlertAcyclicDependencyDetectedDialogViewModel} is the interface definition for {@linkplain AlertAcyclicDependencyDetectedDialogViewModel}
+ */
+public interface IAlertAcyclicDependencyDetectedDialogViewModel extends IViewModel
+{
+
+    /**
+     * Gets the invalid elements to be displayed
+     * 
+     * @return a {@linkplain Map} where the key is a top node for each path where cyclic dependency was detected
+     */
+    ArrayListMultimap<Class, Collection<NamedElement>> GetInvalidElements();
+}

--- a/src/main/java/ViewModels/MagicDrawObjectBrowser/Rows/ElementRowViewModel.java
+++ b/src/main/java/ViewModels/MagicDrawObjectBrowser/Rows/ElementRowViewModel.java
@@ -26,6 +26,7 @@ package ViewModels.MagicDrawObjectBrowser.Rows;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.poi.poifs.property.Parent;
 
 import com.nomagic.uml2.ext.magicdraw.classes.mdkernel.Class;
 import com.nomagic.uml2.ext.magicdraw.classes.mdkernel.Element;
@@ -256,6 +257,7 @@ public abstract class ElementRowViewModel<TElement extends Element> implements I
             }
         }
     }
+    
     /**
      * Updates the represented {@linkplain Element} with the specified one
      * 
@@ -280,5 +282,24 @@ public abstract class ElementRowViewModel<TElement extends Element> implements I
             thisAsParent.GetContainedRows().clear();
             thisAsParent.ComputeContainedRows();
         }
+    }
+    
+    /**
+     * Helper method to get the {@linkplain RootRowViewModel}
+     * 
+     * @return the {@linkplain RootRowViewModel}
+     */
+    protected RootRowViewModel GetRootRowViewModel()
+    {
+        IRowViewModel parent = this.GetParent();
+        IRowViewModel previousParent = this;
+        
+        while(parent != null && !(parent instanceof RootRowViewModel))
+        {
+            parent = parent.GetParent();
+            previousParent = parent;
+        }
+        
+        return (RootRowViewModel) previousParent;
     }
 }

--- a/src/main/java/ViewModels/MagicDrawObjectBrowserViewModel.java
+++ b/src/main/java/ViewModels/MagicDrawObjectBrowserViewModel.java
@@ -39,10 +39,8 @@ import Services.MagicDrawTransaction.IMagicDrawTransactionService;
 import ViewModels.MagicDrawObjectBrowser.MagicDrawObjectBrowserTreeRowViewModel;
 import ViewModels.MagicDrawObjectBrowser.MagicDrawObjectBrowserTreeViewModel;
 import ViewModels.MagicDrawObjectBrowser.Interfaces.IMagicDrawObjectBrowserViewModel;
-import ViewModels.MagicDrawObjectBrowser.Rows.BlockRowViewModel;
 import ViewModels.MagicDrawObjectBrowser.Rows.ClassRowViewModel;
 import ViewModels.MagicDrawObjectBrowser.Rows.ElementRowViewModel;
-import ViewModels.MagicDrawObjectBrowser.Rows.RequirementRowViewModel;
 import Views.MagicDrawObjectBrowser;
 import io.reactivex.Observable;
 

--- a/src/main/java/Views/Dialogs/AlertAcyclicDependencyDetectedDialog.java
+++ b/src/main/java/Views/Dialogs/AlertAcyclicDependencyDetectedDialog.java
@@ -1,0 +1,213 @@
+/*
+ * AlertMoreThanOneCapellaModelOpenDialog.java
+ *
+ * Copyright (c) 2020-2021 RHEA System S.A.
+ *
+ * Author: Sam Gerené, Alex Vorobiev, Nathanael Smiechowski 
+ *
+ * This file is part of DEH-MDSYSML
+ *
+ * The DEH-MDSYSML is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * The DEH-MDSYSML is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package Views.Dialogs;
+
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Map.Entry;
+
+import javax.swing.JButton;
+import javax.swing.JCheckBox;
+import javax.swing.JLabel;
+import javax.swing.JScrollPane;
+
+import com.nomagic.uml2.ext.magicdraw.classes.mdkernel.Class;
+import com.nomagic.uml2.ext.magicdraw.classes.mdkernel.NamedElement;
+
+import Utils.ImageLoader.ImageLoader;
+import ViewModels.Dialogs.Interfaces.IAlertAcyclicDependencyDetectedDialogViewModel;
+import ViewModels.Interfaces.IViewModel;
+import Views.Interfaces.IDialog;
+
+/**
+ * The {@linkplain AlertAcyclicDependencyDetectedDialog} is the dialog where the user gets notify when more than one Capella model is open
+ */
+@SuppressWarnings("serial")
+@Annotations.ExludeFromCodeCoverageGeneratedReport
+public class AlertAcyclicDependencyDetectedDialog extends BaseDialog<Boolean> implements IDialog<IAlertAcyclicDependencyDetectedDialogViewModel, Boolean>
+{
+    /**
+     * This view attached {@linkplain AlertMoreThanOneCapellaModelOpenDialogViewModel} view model
+     */
+    private transient IAlertAcyclicDependencyDetectedDialogViewModel dataContext;
+    
+    /**
+     * The base message that needs to be formatted
+     */
+    private String baseMessage = "<html><p style=\"text-align: center;\">The DEH MagicDraw SysML / Cameo System Modeler Adapter detected cyclic dependencies in the current SysML model.</p>\r\n<p style=\"text-align: center;\">The following elements will be ignored from mapping as they won't be accepted in the Hub.</p><p style=\"text-align: center;\">&nbsp;</p><p style=\"text-align: center;\">%s</p></html>";
+    
+    /**
+     * View components declaration
+     */
+    private JButton okButton;
+    private JLabel message;
+
+    /**
+     * Initializes a new {@linkplain AlertAcyclicDependencyDetectedDialog}
+     */
+    public AlertAcyclicDependencyDetectedDialog() 
+    {
+        this.Initialize();
+    }
+
+    /**
+     * Initializes this view components 
+     */
+    private void Initialize()
+    {
+        this.setTitle("DEH MagicDraw SysML / Cameo System Modeler Adapter warning");
+        this.setSize(600, 448);
+        this.setLocationRelativeTo(null);
+        this.setIconImage(ImageLoader.GetIcon().getImage());
+        this.setType(Type.POPUP);
+        this.setModal(true);
+        
+        GridBagLayout gridBagLayout = new GridBagLayout();
+        gridBagLayout.columnWidths = new int[]{0, 150, 0};
+        gridBagLayout.rowHeights = new int[]{0, 0, 0, 0};
+        gridBagLayout.columnWeights = new double[]{1.0, 0.0, Double.MIN_VALUE};
+        gridBagLayout.rowWeights = new double[]{1.0, 0.0, 0.0, Double.MIN_VALUE};
+        this.getContentPane().setLayout(gridBagLayout);
+        
+        this.message = new JLabel();
+        
+        JScrollPane scrollableTextArea = new JScrollPane(this.message);
+  
+        GridBagConstraints gbc_message = new GridBagConstraints();
+        gbc_message.fill = GridBagConstraints.BOTH;
+        gbc_message.gridwidth = 2;
+        gbc_message.insets = new Insets(5, 5, 5, 5);
+        gbc_message.gridx = 0;
+        gbc_message.gridy = 0;
+        this.getContentPane().add(scrollableTextArea, gbc_message);
+                
+        this.okButton = new JButton("OK");
+        GridBagConstraints gbc_okButton = new GridBagConstraints();
+        gbc_okButton.fill = GridBagConstraints.HORIZONTAL;
+        gbc_okButton.insets = new Insets(5, 5, 5, 5);
+        gbc_okButton.gridx = 1;
+        gbc_okButton.gridy = 2;
+        this.getContentPane().add(this.okButton, gbc_okButton);
+    }
+    
+    /**
+     * Generates a HTML list of faulty elements
+     * 
+     * @return a HTML string
+     */
+    private String GenerateListOfFaultyElements()
+    {
+        StringBuilder faultyElementsList = new StringBuilder();
+        
+        for (Entry<Class, Collection<NamedElement>> entry : this.dataContext.GetInvalidElements().entries())
+        {
+            faultyElementsList.append("<p>");
+            this.AppendToFaultyElementList(faultyElementsList, entry.getKey());
+            
+            for (NamedElement element : entry.getValue())
+            {
+                this.AppendToFaultyElementList(faultyElementsList, element);
+            }
+            
+            this.CloseList(faultyElementsList, entry.getValue().size() + 1);
+        }
+        
+        return faultyElementsList.toString();
+    }
+
+    /**
+     * Closes the HTML formatted string with the correct amount of closing tags
+     * 
+     * @param faultyElementsList the {@linkplain StringBuilder}
+     * @param numberOfentry the number of entry
+     */
+    private void CloseList(StringBuilder faultyElementsList, int numberOfEntry)
+    {
+        for (int entryNumber = 0; entryNumber < numberOfEntry; entryNumber++)
+        {
+            faultyElementsList.append("</li></ul>");
+        }
+
+        faultyElementsList.append("</p>");
+    }
+
+    /**
+     * Appends to the {@linkplain StringBuilder} the provided {@linkplain NamedElement} name
+     * 
+     * @param faultyElementsList the {@linkplain StringBuilder}
+     * @param element the {@linkplain NamedElement}
+     */
+    private void AppendToFaultyElementList(StringBuilder faultyElementsList, NamedElement element)
+    {
+        faultyElementsList.append(String.format("<ul style=\"list-style-type:%s\">", element instanceof Class ? "square" : "circle"));
+        faultyElementsList.append(String.format("<li>%s", element.getName()));
+    }
+
+    /**
+     * Binds the {@linkplain #dataContext} viewModel to this view
+     * 
+     * @param viewModel the view model to bind
+     */
+    @Override
+    public void Bind()
+    {
+        this.okButton.addActionListener(x -> this.CloseDialog(true));
+        this.message.setText(String.format(baseMessage, this.GenerateListOfFaultyElements()));
+    }
+
+    /**
+     * Closes the dialog and sets the {@link dialogResult}
+     * 
+     * @param result the {@linkplain TResult} to set
+     */
+    @Override
+    public void CloseDialog(Boolean result)
+    {
+        super.CloseDialog(result);
+    }
+    
+    /**
+     * Sets the DataContext
+     */
+     @Override
+    public void SetDataContext(IAlertAcyclicDependencyDetectedDialogViewModel viewModel)
+    {
+        this.dataContext = viewModel;
+        this.Bind();        
+    }
+
+    /**
+     * Gets the DataContext
+     * 
+     * @return an {@link IViewModel}
+     */
+    @Override
+    public IAlertAcyclicDependencyDetectedDialogViewModel GetDataContext()
+    {
+        return this.dataContext;
+    }
+}

--- a/src/test/java/Services/MappingConfiguration/MagicDrawMappingConfigurationServiceTest.java
+++ b/src/test/java/Services/MappingConfiguration/MagicDrawMappingConfigurationServiceTest.java
@@ -45,6 +45,9 @@ import com.nomagic.uml2.ext.magicdraw.classes.mdkernel.Class;
 import Enumerations.MappingDirection;
 import HubController.IHubController;
 import Services.MagicDrawTransaction.IMagicDrawTransactionService;
+import Services.MagicDrawUILog.IMagicDrawUILogService;
+import Services.ModelConsistency.ICircularDependencyValidationService;
+import Services.NavigationService.INavigationService;
 import Services.Stereotype.IStereotypeService;
 import Utils.Ref;
 import Utils.Stereotypes.Stereotypes;
@@ -62,6 +65,9 @@ class MagicDrawMappingConfigurationServiceTest
     private ElementDefinition elementDefinition;
     private Requirement requirement;
     private Class dstRequirement;
+    private ICircularDependencyValidationService circularDependencyValidationService;
+    private INavigationService navigationService;
+    private IMagicDrawUILogService logService;
 
     @BeforeEach
     void setUp() throws Exception
@@ -69,10 +75,14 @@ class MagicDrawMappingConfigurationServiceTest
         this.hubController = mock(IHubController.class);
         this.stereotypeService = mock(IStereotypeService.class);
         this.transactionService = mock(IMagicDrawTransactionService.class);
+        this.circularDependencyValidationService = mock(ICircularDependencyValidationService.class);
+        this.navigationService = mock(INavigationService.class);
+        this.logService = mock(IMagicDrawUILogService.class);
         
         when(this.hubController.GetIsSessionOpenObservable()).thenReturn(Observable.fromArray(true, false));
         
-        this.service = new MagicDrawMappingConfigurationService(this.hubController, this.transactionService, this.stereotypeService);
+        this.service = new MagicDrawMappingConfigurationService(this.hubController, this.transactionService, this.stereotypeService, 
+                this.circularDependencyValidationService, this.navigationService, this.logService);
     }
     
     @SuppressWarnings("unchecked")

--- a/src/test/java/Services/ModelConsistency/CircularDependencyValidationServiceTestFixture.java
+++ b/src/test/java/Services/ModelConsistency/CircularDependencyValidationServiceTestFixture.java
@@ -1,0 +1,337 @@
+/*
+ * CircularDependencyValidationServiceTestFixture.java
+ *
+ * Copyright (c) 2020-2021 RHEA System S.A.
+ *
+ * Author: Sam Gerené, Alex Vorobiev, Nathanael Smiechowski 
+ *
+ * This file is part of DEH-MDSYSML
+ *
+ * The DEH-MDSYSML is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * The DEH-MDSYSML is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package Services.ModelConsistency;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.any;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.nomagic.magicdraw.core.Project;
+import com.nomagic.uml2.ext.magicdraw.classes.mdkernel.Class;
+import com.nomagic.uml2.ext.magicdraw.classes.mdkernel.DataType;
+import com.nomagic.uml2.ext.magicdraw.classes.mdkernel.Element;
+import com.nomagic.uml2.ext.magicdraw.classes.mdkernel.Package;
+import com.nomagic.uml2.ext.magicdraw.classes.mdkernel.Property;
+import com.nomagic.uml2.ext.magicdraw.compositestructures.mdports.Port;
+
+import Reactive.ObservableValue;
+import Services.MagicDrawSession.IMagicDrawSessionService;
+import Services.MagicDrawUILog.IMagicDrawUILogService;
+import Services.Stereotype.IStereotypeService;
+import Utils.Ref;
+import Utils.Stereotypes.Stereotypes;
+
+public class CircularDependencyValidationServiceTestFixture
+{
+    private IMagicDrawSessionService sessionService;
+    private IStereotypeService stereotypeService;
+    private IMagicDrawUILogService logService;
+    private CircularDependencyValidationService service;
+    private Collection<Element> elements = new ArrayList<>();
+    private ObservableValue<Boolean> projectSavedObservable;
+    private ObservableValue<Boolean> sessionOpenObservable;
+    private ObservableValue<Boolean> sessionEventObservable;
+
+    @BeforeEach
+    public void Setup()
+    {
+        this.sessionService = mock(IMagicDrawSessionService.class);
+        this.stereotypeService = mock(IStereotypeService.class);
+        this.logService = mock(IMagicDrawUILogService.class);
+
+        this.SetupElements();
+        this.projectSavedObservable = new ObservableValue<Boolean>(false, Boolean.class);
+        this.sessionOpenObservable = new ObservableValue<Boolean>(false, Boolean.class);
+        this.sessionEventObservable = new ObservableValue<Boolean>(false, Boolean.class);
+        
+        when(this.sessionService.GetProjectName()).thenReturn("MODEL");
+        when(this.sessionService.GetAllProjectElements()).thenReturn(this.elements);
+        when(this.sessionService.ProjectSaved()).thenReturn(this.projectSavedObservable.Observable());
+        when(this.sessionService.HasAnyOpenSessionObservable()).thenReturn(this.sessionOpenObservable.Observable());
+        when(this.sessionService.GetSessionEvent()).thenReturn(this.sessionEventObservable);
+        when(this.stereotypeService.DoesItHaveTheStereotype(any(), any())).thenReturn(true);
+        when(this.stereotypeService.IsPartProperty(any())).thenReturn(true);
+                
+        this.service = new CircularDependencyValidationService(this.sessionService, this.stereotypeService, this.logService);
+    }
+
+    private void SetupElements()
+    {
+        Package mainPackage = mock(Package.class);
+        when(mainPackage.getName()).thenReturn("Package");
+        ArrayList<Element> containedElements = new ArrayList<>();
+        when(mainPackage.getOwnedElement()).thenReturn(containedElements);
+
+        Class typeBlock = mock(Class.class);
+        when(typeBlock.getName()).thenReturn("TypeBlock");
+        ArrayList<Property> typeBlockProperties = new ArrayList<>();
+        when(typeBlock.getOwnedAttribute()).thenReturn(typeBlockProperties);
+        
+        Property refProperty = mock(Property.class);
+        when(this.stereotypeService.IsReferenceProperty(refProperty)).thenReturn(true);
+        typeBlockProperties.add(refProperty);
+        
+        Property valProperty = mock(Property.class);
+        when(this.stereotypeService.IsValueProperty(valProperty)).thenReturn(true);
+        typeBlockProperties.add(valProperty);
+        
+        Property partPropertySameId = mock(Property.class);
+        when(partPropertySameId.getID()).thenReturn(UUID.randomUUID().toString());
+        when(this.stereotypeService.IsPartProperty(partPropertySameId)).thenReturn(true);
+        typeBlockProperties.add(partPropertySameId);
+        
+        Property partPropertyOtherId = mock(Property.class);
+        String id = UUID.randomUUID().toString();
+        when(partPropertyOtherId.getID()).thenReturn(id);
+        when(this.stereotypeService.IsPartProperty(partPropertyOtherId)).thenReturn(true);
+        typeBlockProperties.add(partPropertyOtherId);
+        
+        Property valTypeProperty = mock(Property.class);
+        when(this.stereotypeService.IsPartProperty(valTypeProperty)).thenReturn(false);
+        typeBlockProperties.add(valTypeProperty);
+
+        Class block = mock(Class.class);
+        when(block.getName()).thenReturn("block");
+        when(this.stereotypeService.DoesItHaveTheStereotype(block, Stereotypes.Block)).thenReturn(true);
+
+        ArrayList<Property> properties = new ArrayList<>();
+        Property referenceProperty = mock(Property.class);
+        when(this.stereotypeService.IsReferenceProperty(referenceProperty)).thenReturn(true);
+        properties.add(referenceProperty);
+
+        Property valuePropertyDataType = mock(Property.class);
+        when(valuePropertyDataType.getType()).thenReturn(mock(DataType.class));
+        when(this.stereotypeService.IsValueProperty(valuePropertyDataType)).thenReturn(false);
+        properties.add(valuePropertyDataType);
+
+        Property partProperty = mock(Property.class);
+        when(this.stereotypeService.IsPartProperty(partProperty)).thenReturn(true);
+        when(partProperty.getType()).thenReturn(typeBlock);
+        when(partProperty.getID()).thenReturn(id);
+        properties.add(partProperty);
+        
+        Property valueProperty = mock(Property.class);
+        when(this.stereotypeService.IsValueProperty(valuePropertyDataType)).thenReturn(true, false);
+        properties.add(valueProperty);
+        properties.add(valueProperty);
+
+        Property partProperty2 = mock(Property.class);
+        when(partProperty2.getType()).thenReturn(mock(Class.class));
+        when(this.stereotypeService.IsValueProperty(partProperty2)).thenReturn(false);
+        properties.add(partProperty2);
+
+        when(block.getOwnedAttribute()).thenReturn(properties);
+
+        Port port = mock(Port.class);
+        ArrayList<Port> ports = new ArrayList<>();
+        ports.add(port);
+        when(block.getOwnedPort()).thenReturn(ports);
+
+        Class requirement = mock(Class.class);
+        when(requirement.getName()).thenReturn("requirement");
+        when(this.stereotypeService.DoesItHaveTheStereotype(requirement, Stereotypes.Requirement)).thenReturn(true);
+
+        containedElements.add(block);
+        containedElements.add(requirement);
+
+        this.elements.addAll(containedElements);
+    }
+    
+    @Test
+    public void VerifyValidationTask()
+    {
+        assertDoesNotThrow(() -> this.sessionOpenObservable.Value(true));
+        when(this.sessionService.HasAnyOpenSession()).thenReturn(true);
+        assertDoesNotThrow(() -> this.sessionOpenObservable.Value(true));
+        assertEquals(0, this.service.GetInvalidPaths().size());
+    }
+    
+    @Test
+    public void VerifyWhenThereIsCircularDependency()
+    {
+        when(this.sessionService.HasAnyOpenSession()).thenReturn(true);
+        Package mainPackage = mock(Package.class);
+        when(mainPackage.getName()).thenReturn("Package");
+
+        this.elements.add(mainPackage);
+        ArrayList<Element> containedElements = new ArrayList<>();
+        when(mainPackage.getOwnedElement()).thenReturn(containedElements);
+
+        Class blockA = mock(Class.class);
+        when(blockA.getName()).thenReturn("blockB");
+        when(this.stereotypeService.DoesItHaveTheStereotype(blockA, Stereotypes.Block)).thenReturn(true);
+        containedElements.add(blockA);
+        
+        ArrayList<Property> blockAProperties = new ArrayList<>();
+        when(blockA.getOwnedAttribute()).thenReturn(blockAProperties);
+
+        Class blockB = mock(Class.class);
+        when(blockB.getName()).thenReturn("blockB");
+        when(this.stereotypeService.DoesItHaveTheStereotype(blockB, Stereotypes.Block)).thenReturn(true);
+        containedElements.add(blockB);
+        
+        ArrayList<Property> blockBProperties = new ArrayList<>();
+        when(blockB.getOwnedAttribute()).thenReturn(blockBProperties);
+
+        Property partPropertyA = mock(Property.class);
+        when(partPropertyA.getID()).thenReturn(UUID.randomUUID().toString());
+        when(partPropertyA.getType()).thenReturn(blockA);
+        when(this.stereotypeService.IsPartProperty(partPropertyA)).thenReturn(true);
+        when(partPropertyA.getObjectParent()).thenReturn(blockB);
+        blockBProperties.add(partPropertyA);
+        
+        Property partPropertyB = mock(Property.class);
+        when(partPropertyB.getID()).thenReturn(UUID.randomUUID().toString());
+        when(partPropertyA.getType()).thenReturn(blockB);
+        when(this.stereotypeService.IsPartProperty(partPropertyB)).thenReturn(true);
+        when(partPropertyB.getObjectParent()).thenReturn(blockA);
+        blockAProperties.add(partPropertyB);
+        when(this.sessionService.GetAllProjectElements()).thenReturn(containedElements);
+        
+        assertFalse(this.service.Validate());
+        assertDoesNotThrow(() -> this.projectSavedObservable.Value(true));
+        assertEquals(1, this.service.GetInvalidPaths().size());
+    }
+
+    @Test
+    public void VerifyWhenThereIsMoreThanOnePath()
+    {
+        when(this.sessionService.HasAnyOpenSession()).thenReturn(true);
+        
+        ArrayList<Element> containedElements = new ArrayList<>();
+
+        Class mission = mock(Class.class);
+        when(mission.getName()).thenReturn("mission");
+        when(mission.getID()).thenReturn(UUID.randomUUID().toString());
+        when(this.stereotypeService.DoesItHaveTheStereotype(mission, Stereotypes.Block)).thenReturn(true);
+        containedElements.add(mission);
+        
+        ArrayList<Property> missionProperties = new ArrayList<>();
+        when(mission.getOwnedAttribute()).thenReturn(missionProperties);
+
+        Class groundSegment = mock(Class.class);
+        when(groundSegment.getName()).thenReturn("groundSegment");
+        when(groundSegment.getID()).thenReturn(UUID.randomUUID().toString());
+        when(this.stereotypeService.DoesItHaveTheStereotype(groundSegment, Stereotypes.Block)).thenReturn(true);
+        containedElements.add(groundSegment);
+        
+        ArrayList<Property> groundSegmentProperties = new ArrayList<>();
+        when(groundSegment.getOwnedAttribute()).thenReturn(groundSegmentProperties);
+        
+        Class antenna = mock(Class.class);
+        when(antenna.getName()).thenReturn("antenna");
+        when(antenna.getID()).thenReturn(UUID.randomUUID().toString());
+        when(this.stereotypeService.DoesItHaveTheStereotype(antenna, Stereotypes.Block)).thenReturn(true);
+        containedElements.add(antenna);
+        
+        ArrayList<Property> antennaProperties = new ArrayList<>();
+        when(antenna.getOwnedAttribute()).thenReturn(antennaProperties);
+        
+        Class station0 = mock(Class.class);
+        when(station0.getName()).thenReturn("station0");
+        when(station0.getID()).thenReturn(UUID.randomUUID().toString());
+        when(this.stereotypeService.DoesItHaveTheStereotype(station0, Stereotypes.Block)).thenReturn(true);
+        containedElements.add(station0);
+        
+        ArrayList<Property> station0Properties = new ArrayList<>();
+        when(station0.getOwnedAttribute()).thenReturn(station0Properties);
+        
+        Class station1 = mock(Class.class);
+        when(station1.getName()).thenReturn("station1");
+        when(station1.getID()).thenReturn(UUID.randomUUID().toString());
+        when(this.stereotypeService.DoesItHaveTheStereotype(station1, Stereotypes.Block)).thenReturn(true);
+        containedElements.add(station1);
+        
+        ArrayList<Property> station1Properties = new ArrayList<>();
+        when(station1.getOwnedAttribute()).thenReturn(station1Properties);        
+
+        Class station2 = mock(Class.class);
+        when(station2.getName()).thenReturn("station2");
+        when(station2.getID()).thenReturn(UUID.randomUUID().toString());
+        when(this.stereotypeService.DoesItHaveTheStereotype(station2, Stereotypes.Block)).thenReturn(true);
+        containedElements.add(station2);
+        
+        ArrayList<Property> station2Properties = new ArrayList<>();
+        when(station2.getOwnedAttribute()).thenReturn(station2Properties);
+        
+        Property partPropertyMission = mock(Property.class);
+        when(partPropertyMission.getID()).thenReturn(UUID.randomUUID().toString());
+        when(partPropertyMission.getType()).thenReturn(groundSegment);
+        when(partPropertyMission.getObjectParent()).thenReturn(mission);
+        missionProperties.add(partPropertyMission);
+        
+        Property partPropertyGroundSegment0 = mock(Property.class);
+        when(partPropertyGroundSegment0.getID()).thenReturn(UUID.randomUUID().toString());
+        when(partPropertyGroundSegment0.getType()).thenReturn(station0);
+        when(partPropertyGroundSegment0.getObjectParent()).thenReturn(groundSegment);
+        groundSegmentProperties.add(partPropertyGroundSegment0);        
+
+        Property partPropertyGroundSegment1 = mock(Property.class);
+        when(partPropertyGroundSegment1.getID()).thenReturn(UUID.randomUUID().toString());
+        when(partPropertyGroundSegment1.getType()).thenReturn(station1);
+        when(partPropertyGroundSegment1.getObjectParent()).thenReturn(groundSegment);
+        groundSegmentProperties.add(partPropertyGroundSegment1);
+
+        Property partPropertyGroundSegment2 = mock(Property.class);
+        when(partPropertyGroundSegment2.getID()).thenReturn(UUID.randomUUID().toString());
+        when(partPropertyGroundSegment2.getType()).thenReturn(station2);
+        when(partPropertyGroundSegment2.getObjectParent()).thenReturn(groundSegment);
+        groundSegmentProperties.add(partPropertyGroundSegment2);
+        
+        Property partPropertyStation0 = mock(Property.class);
+        when(partPropertyStation0.getID()).thenReturn(UUID.randomUUID().toString());
+        when(partPropertyStation0.getType()).thenReturn(antenna);
+        when(partPropertyStation0.getObjectParent()).thenReturn(station0);
+        groundSegmentProperties.add(partPropertyStation0);        
+
+        Property partPropertyStation1 = mock(Property.class);
+        when(partPropertyStation1.getID()).thenReturn(UUID.randomUUID().toString());
+        when(partPropertyStation1.getType()).thenReturn(antenna);
+        when(partPropertyStation1.getObjectParent()).thenReturn(station1);
+        groundSegmentProperties.add(partPropertyStation1);
+
+        Property partPropertyStation2 = mock(Property.class);
+        when(partPropertyStation2.getID()).thenReturn(UUID.randomUUID().toString());
+        when(partPropertyStation2.getType()).thenReturn(antenna);
+        when(partPropertyStation2.getObjectParent()).thenReturn(station2);
+        groundSegmentProperties.add(partPropertyStation2);
+        
+        when(this.sessionService.GetAllProjectElements()).thenReturn(containedElements);
+        
+        assertTrue(this.service.Validate());
+        assertDoesNotThrow(() -> this.projectSavedObservable.Value(true));
+        assertEquals(0, this.service.GetInvalidPaths().size());
+    }
+}

--- a/src/test/java/ViewModels/Dialogs/DstToHubMappingConfigurationDialogViewModelTest.java
+++ b/src/test/java/ViewModels/Dialogs/DstToHubMappingConfigurationDialogViewModelTest.java
@@ -49,6 +49,8 @@ import HubController.IHubController;
 import Reactive.ObservableCollection;
 import Reactive.ObservableValue;
 import Services.MagicDrawTransaction.IMagicDrawTransactionService;
+import Services.ModelConsistency.ICircularDependencyValidationService;
+import Services.NavigationService.INavigationService;
 import Services.Stereotype.IStereotypeService;
 import Utils.Stereotypes.Stereotypes;
 import ViewModels.Interfaces.IElementDefinitionBrowserViewModel;
@@ -90,6 +92,8 @@ class DstToHubMappingConfigurationDialogViewModelTest
 	ObservableCollection<MappedElementRowViewModel<DefinedThing, Class>> dstMapResult;
 	Iteration iteration;
     private IMagicDrawTransactionService transactionService;
+    private ICircularDependencyValidationService circularDependencyService;
+    private INavigationService navigationService;
 
 	@SuppressWarnings("unchecked")
 	@BeforeEach
@@ -109,6 +113,8 @@ class DstToHubMappingConfigurationDialogViewModelTest
 		this.mappedElementListViewViewModel = mock(IMappedElementListViewViewModel.class);
 		this.stereotypeService = mock(IStereotypeService.class);
 		this.transactionService = mock(IMagicDrawTransactionService.class);
+		this.circularDependencyService = mock(ICircularDependencyValidationService.class);
+		this.navigationService = mock(INavigationService.class);
 
 		DomainOfExpertise domain = new DomainOfExpertise();
 		domain.setName("THERMAL");
@@ -133,7 +139,8 @@ class DstToHubMappingConfigurationDialogViewModelTest
 
 		this.viewModel = new DstToHubMappingConfigurationDialogViewModel(this.dstController, this.hubController,
 				this.elementDefinitionBrowserViewModel, this.requirementBrowserViewModel,
-				this.magicDrawObjectBrowserViewModel, this.mappedElementListViewViewModel, this.stereotypeService);
+				this.magicDrawObjectBrowserViewModel, this.mappedElementListViewViewModel, 
+				this.stereotypeService, this.circularDependencyService, this.navigationService);
 	}
 
 	@Test


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/DEH-MDSYSML/pulls) open
- [x] I have verified that I am following the DEH-MDSYSML [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/DEH-MDSYSML/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
fixes #108 

- [x] Implement a Service that knows about every path in the model where each node is a block and each Part is an edge, in order to detect circular dependencies.
- [x] Prevent the Impact view to compute the tree until a stack overflow exception is thrown
- [x] Prevent any new mapping to be defined from any block that is part of a circular dependency, by warning the user.
- [x] Prevent any existing mapping to be reloaded automatically if any block that is part of a circular dependency, by warning the user
<!-- Thanks for contributing to DEH-MDSYSML! -->